### PR TITLE
fix conditional_multipurpose_modmap and add timeout

### DIFF
--- a/example/config.py
+++ b/example/config.py
@@ -3,6 +3,9 @@
 import re
 from xkeysnail.transform import *
 
+# define timeout for multipurpose_modmap
+define_timeout(1)
+
 # [Global modemap] Change modifier keys as in xmodmap
 define_modmap({
     Key.CAPSLOCK: Key.LEFT_CTRL

--- a/xkeysnail/transform.py
+++ b/xkeysnail/transform.py
@@ -347,6 +347,9 @@ def multipurpose_handler(multipurpose_map, key, action):
                 on_key(mod_key, Action.RELEASE)
         elif action == Action.PRESS and not key_is_down:
             set_key_state(Action.PRESS)
+        elif action == Action.RELEASE:
+            update_pressed_modifier_keys(key, action)
+            send_key_action(key, action)
     # if key is not a multipurpose or mod key we want eventual modifiers down
     elif (key not in Modifier.get_all_keys()) and action == Action.PRESS:
         maybe_press_modifiers(multipurpose_map)


### PR DESCRIPTION
Resolving conflicts of conditional_multipurpose_modmap when switching windows.

A window switch when a key is pressed will cause an error in the key state.Use a globally unified key state for recording to solve this problem.